### PR TITLE
Thesis #1: Cache regex compilation in parsers

### DIFF
--- a/lib/language.js
+++ b/lib/language.js
@@ -85,9 +85,14 @@ function parseLanguage(str, i) {
 
 function getLanguagePriority(language, accepted, index) {
   var priority = {o: -1, q: 0, s: 0};
+  var p = parseLanguage(language);
+
+  if (!p) {
+    return priority;
+  }
 
   for (var i = 0; i < accepted.length; i++) {
-    var spec = specify(language, accepted[i], index);
+    var spec = specifyParsed(p, accepted[i], index);
 
     if (spec && (priority.s - spec.s || priority.q - spec.q || priority.o - spec.o) < 0) {
       priority = spec;
@@ -105,6 +110,31 @@ function getLanguagePriority(language, accepted, index) {
 function specify(language, spec, index) {
   var p = parseLanguage(language)
   if (!p) return null;
+  var s = 0;
+  if(spec.full.toLowerCase() === p.full.toLowerCase()){
+    s |= 4;
+  } else if (spec.prefix.toLowerCase() === p.full.toLowerCase()) {
+    s |= 2;
+  } else if (spec.full.toLowerCase() === p.prefix.toLowerCase()) {
+    s |= 1;
+  } else if (spec.full !== '*' ) {
+    return null
+  }
+
+  return {
+    i: index,
+    o: spec.i,
+    q: spec.q,
+    s: s
+  }
+};
+
+/**
+ * Get the specificity of the language using pre-parsed language.
+ * @private
+ */
+
+function specifyParsed(p, spec, index) {
   var s = 0;
   if(spec.full.toLowerCase() === p.full.toLowerCase()){
     s |= 4;

--- a/lib/mediaType.js
+++ b/lib/mediaType.js
@@ -98,9 +98,14 @@ function parseMediaType(str, i) {
 
 function getMediaTypePriority(type, accepted, index) {
   var priority = {o: -1, q: 0, s: 0};
+  var parsedType = parseMediaType(type);
+
+  if (!parsedType) {
+    return priority;
+  }
 
   for (var i = 0; i < accepted.length; i++) {
-    var spec = specify(type, accepted[i], index);
+    var spec = specifyParsed(parsedType, accepted[i], index);
 
     if (spec && (priority.s - spec.s || priority.q - spec.q || priority.o - spec.o) < 0) {
       priority = spec;
@@ -122,6 +127,45 @@ function specify(type, spec, index) {
   if (!p) {
     return null;
   }
+
+  if(spec.type.toLowerCase() == p.type.toLowerCase()) {
+    s |= 4
+  } else if(spec.type != '*') {
+    return null;
+  }
+
+  if(spec.subtype.toLowerCase() == p.subtype.toLowerCase()) {
+    s |= 2
+  } else if(spec.subtype != '*') {
+    return null;
+  }
+
+  var keys = Object.keys(spec.params);
+  if (keys.length > 0) {
+    if (keys.every(function (k) {
+      return spec.params[k] == '*' || (spec.params[k] || '').toLowerCase() == (p.params[k] || '').toLowerCase();
+    })) {
+      s |= 1
+    } else {
+      return null
+    }
+  }
+
+  return {
+    i: index,
+    o: spec.i,
+    q: spec.q,
+    s: s,
+  }
+}
+
+/**
+ * Get the specificity of the media type using pre-parsed type.
+ * @private
+ */
+
+function specifyParsed(p, spec, index) {
+  var s = 0;
 
   if(spec.type.toLowerCase() == p.type.toLowerCase()) {
     s |= 4


### PR DESCRIPTION
References #1

Self-reported metric: 59366.8800
Baseline: 48448.7200
Summary: Cached regex parsing results by parsing media types and languages once in getMediaTypePriority/getLanguagePriority instead of repeatedly in specify() for each comparison. This eliminates redundant regex compilation and object creation in the hot path. Performance improved from 48448.72 to 59366.88 ops/sec (+22.5%).