### PR TITLE
Thesis #7: Memoize parseMediaType results in specify function

### DIFF
--- a/lib/mediaType.js
+++ b/lib/mediaType.js
@@ -22,6 +22,7 @@ module.exports.preferredMediaTypes = preferredMediaTypes;
  */
 
 var simpleMediaTypeRegExp = /^\s*([^\s\/;]+)\/([^;\s]+)\s*(?:;(.*))?$/;
+var parseMediaTypeCache = Object.create(null);
 
 /**
  * Parse the Accept header.
@@ -98,7 +99,12 @@ function parseMediaType(str, i) {
 
 function getMediaTypePriority(type, accepted, index) {
   var priority = {o: -1, q: 0, s: 0};
-  var parsedType = parseMediaType(type);
+  var parsedType = parseMediaTypeCache[type];
+
+  if (parsedType === undefined) {
+    parsedType = parseMediaType(type);
+    parseMediaTypeCache[type] = parsedType;
+  }
 
   if (!parsedType) {
     return priority;
@@ -121,7 +127,13 @@ function getMediaTypePriority(type, accepted, index) {
  */
 
 function specify(type, spec, index) {
-  var p = parseMediaType(type);
+  var p = parseMediaTypeCache[type];
+
+  if (p === undefined) {
+    p = parseMediaType(type);
+    parseMediaTypeCache[type] = p;
+  }
+
   var s = 0;
 
   if (!p) {


### PR DESCRIPTION
References #7

Self-reported metric: 63921.3900
Baseline: 61757.6900
Summary: Memoized parseMediaType results using module-level cache, eliminating redundant parsing. Tests pass, 3.5% improvement.