### PR TITLE
Thesis #9: Cache Object.keys for spec params

### DIFF
--- a/lib/mediaType.js
+++ b/lib/mediaType.js
@@ -87,6 +87,7 @@ function parseMediaType(str, i) {
     type: type,
     subtype: subtype,
     params: params,
+    paramKeys: Object.keys(params),
     q: q,
     i: i
   };
@@ -152,7 +153,7 @@ function specify(type, spec, index) {
     return null;
   }
 
-  var keys = Object.keys(spec.params);
+  var keys = spec.paramKeys;
   if (keys.length > 0) {
     if (keys.every(function (k) {
       return spec.params[k] == '*' || (spec.params[k] || '').toLowerCase() == (p.params[k] || '').toLowerCase();
@@ -191,7 +192,7 @@ function specifyParsed(p, spec, index) {
     return null;
   }
 
-  var keys = Object.keys(spec.params);
+  var keys = spec.paramKeys;
   if (keys.length > 0) {
     if (keys.every(function (k) {
       return spec.params[k] == '*' || (spec.params[k] || '').toLowerCase() == (p.params[k] || '').toLowerCase();


### PR DESCRIPTION
References #9

Self-reported metric: 64904.5500
Baseline: 63921.3900
Summary: Cached Object.keys(params) as paramKeys during parseMediaType to avoid repeated O(n) Object.keys() calls in specify/specifyParsed hot paths. Performance improved from 63921.39 to ~64905 ops/sec (+1.5%).